### PR TITLE
Bitvector: decompress_bit_vector_without_checks method added

### DIFF
--- a/cctp_primitives/src/bit_vector/compression.rs
+++ b/cctp_primitives/src/bit_vector/compression.rs
@@ -147,6 +147,20 @@ pub fn decompress_bit_vector(compressed_bit_vector: &[u8], expected_size: usize)
     Ok(raw_bit_vector_result)
 }
 
+#[allow(unused_variables)]
+pub fn decompress_bit_vector_without_checks(compressed_bit_vector: &[u8]) -> Result<Vec<u8>, Error> {
+
+    let mut raw_bit_vector_result =  match compressed_bit_vector[0].try_into() {
+        Ok(CompressionAlgorithm::Uncompressed) => Ok(compressed_bit_vector[1..].to_vec()),
+        Ok(CompressionAlgorithm::Bzip2) => bzip2_decompress(&compressed_bit_vector[1..]),
+        Ok(CompressionAlgorithm::Gzip) => gzip_decompress(&compressed_bit_vector[1..]),
+        Err(_) => Err("Compression algorithm not supported")?
+    }?;
+
+    raw_bit_vector_result.shrink_to_fit();
+    Ok(raw_bit_vector_result)
+}
+
 fn bzip2_compress(bit_vector: &[u8]) -> Result<Vec<u8>, Error> {
     let mut compressor = BzEncoder::new(bit_vector, bzip2::Compression::best());
     let mut bzip_compressed = Vec::new();

--- a/cctp_primitives/src/bit_vector/merkle_tree.rs
+++ b/cctp_primitives/src/bit_vector/merkle_tree.rs
@@ -83,6 +83,13 @@ pub fn merkle_root_from_compressed_bytes(compressed_bit_vector: &[u8], expected_
 
 }
 
+pub fn merkle_root_from_compressed_bytes_without_checks(compressed_bit_vector: &[u8]) -> Result<algebra::Fp256<algebra::fields::tweedle::FrParameters>, Error> {
+
+    let uncompressed_bit_vector = compression::decompress_bit_vector_without_checks(compressed_bit_vector)?;
+    merkle_root_from_bytes(&uncompressed_bit_vector)
+
+}
+
 #[cfg(test)]
 mod test {
 
@@ -107,6 +114,18 @@ mod test {
         
         assert!(merkle_root_from_compressed_bytes(&bit_vector, bit_vector.len() - 1).is_ok());
 
+    }
+
+    #[test]
+    fn without_size_checks() {
+        let mut bit_vector: Vec<u8> = vec!();
+        bit_vector.push(0);
+
+        for i in 0..63 {
+            bit_vector.push(i);
+        }
+
+        assert!(merkle_root_from_compressed_bytes_without_checks(&bit_vector).is_ok());
     }
 
     #[test]

--- a/cctp_primitives/src/bit_vector/merkle_tree.rs
+++ b/cctp_primitives/src/bit_vector/merkle_tree.rs
@@ -102,8 +102,10 @@ mod test {
     fn expected_size() {
         let mut bit_vector: Vec<u8> = vec![0; 63];
 
-        // Since the first byte specifies the compression algorithm, an error is expected.
+        // Expect for an error because if the different expected uncompressed size.
         assert!(merkle_root_from_compressed_bytes(&bit_vector, bit_vector.len()).is_err());
+        // No errors expected if the uncompressed size is fine.
+        assert!(merkle_root_from_compressed_bytes(&bit_vector, bit_vector.len() - 1).is_ok());
 
         bit_vector.clear();
         bit_vector.push(0);
@@ -118,7 +120,10 @@ mod test {
 
     #[test]
     fn without_size_checks() {
-        let mut bit_vector: Vec<u8> = vec!();
+        let mut bit_vector: Vec<u8> = vec![0; 63];
+        assert!(merkle_root_from_compressed_bytes_without_checks(&bit_vector).is_ok());
+
+        bit_vector.clear();
         bit_vector.push(0);
 
         for i in 0..63 {

--- a/cctp_primitives/src/bit_vector/merkle_tree.rs
+++ b/cctp_primitives/src/bit_vector/merkle_tree.rs
@@ -102,7 +102,7 @@ mod test {
     fn expected_size() {
         let mut bit_vector: Vec<u8> = vec![0; 63];
 
-        // Expect for an error because if the different expected uncompressed size.
+        // Expect for an error because of the different uncompressed size.
         assert!(merkle_root_from_compressed_bytes(&bit_vector, bit_vector.len()).is_err());
         // No errors expected if the uncompressed size is fine.
         assert!(merkle_root_from_compressed_bytes(&bit_vector, bit_vector.len() - 1).is_ok());


### PR DESCRIPTION
Sidechains don't know the expected size of the bitvector decompression result, so they are not able to get the bitvector merkle root -> not able to use it in the CommitmentTree.