### PR TITLE
Misc Changes 2

### DIFF
--- a/cctp_primitives/src/bit_vector/compression.rs
+++ b/cctp_primitives/src/bit_vector/compression.rs
@@ -125,13 +125,25 @@ pub fn compress_bit_vector(raw_bit_vector: &[u8], algorithm: CompressionAlgorith
 /// ```
 #[allow(unused_variables)]
 pub fn decompress_bit_vector(compressed_bit_vector: &[u8], expected_size: usize) -> Result<Vec<u8>, Error> {
-    
+    decompress_bit_vector_with_opt_checks(compressed_bit_vector, Some(expected_size))
+}
+
+#[allow(unused_variables)]
+pub fn decompress_bit_vector_without_checks(compressed_bit_vector: &[u8]) -> Result<Vec<u8>, Error> {
+    decompress_bit_vector_with_opt_checks(compressed_bit_vector, None)
+}
+
+#[allow(unused_variables)]
+fn decompress_bit_vector_with_opt_checks(compressed_bit_vector: &[u8], expected_size_opt: Option<usize>) -> Result<Vec<u8>, Error> {
+
     printlndbg!("Decompressing bit vector...");
-    printlndbg!("Algorithm: {}, size: {}, expected decompressed size: {}, address: {:p}", compressed_bit_vector[0], compressed_bit_vector.len(), expected_size, compressed_bit_vector);
+    printlndbg!("Algorithm: {}, size: {}, expected decompressed size: {} (check: {}), address: {:p}",
+    compressed_bit_vector[0], compressed_bit_vector.len(),
+    expected_size_opt.unwrap_or_default(), expected_size_opt.is_some(), compressed_bit_vector);
 
     printlndbg!("Bit vector content:");
     printlndbg!("{:x?}", compressed_bit_vector);
-        
+
     let mut raw_bit_vector_result =  match compressed_bit_vector[0].try_into() {
         Ok(CompressionAlgorithm::Uncompressed) => Ok(compressed_bit_vector[1..].to_vec()),
         Ok(CompressionAlgorithm::Bzip2) => bzip2_decompress(&compressed_bit_vector[1..]),
@@ -139,8 +151,11 @@ pub fn decompress_bit_vector(compressed_bit_vector: &[u8], expected_size: usize)
         Err(_) => Err("Compression algorithm not supported")?
     }?;
 
-    if raw_bit_vector_result.len() != expected_size {
-        Err(format!("Wrong bit vector size. Expected {} bytes, found {} bytes", expected_size, raw_bit_vector_result.len()))?
+    if expected_size_opt.is_some() {
+        let expected_size = expected_size_opt.unwrap();
+        if raw_bit_vector_result.len() != expected_size {
+            Err(format!("Wrong bit vector size. Expected {} bytes, found {} bytes", expected_size, raw_bit_vector_result.len()))?
+        }
     }
 
     raw_bit_vector_result.shrink_to_fit();

--- a/cctp_primitives/src/bit_vector/merkle_tree.rs
+++ b/cctp_primitives/src/bit_vector/merkle_tree.rs
@@ -83,6 +83,13 @@ pub fn merkle_root_from_compressed_bytes(compressed_bit_vector: &[u8], expected_
 
 }
 
+pub fn merkle_root_from_compressed_bytes_without_checks(compressed_bit_vector: &[u8]) -> Result<algebra::Fp256<algebra::fields::tweedle::FrParameters>, Error> {
+
+    let uncompressed_bit_vector = compression::decompress_bit_vector_without_checks(compressed_bit_vector)?;
+    merkle_root_from_bytes(&uncompressed_bit_vector)
+
+}
+
 #[cfg(test)]
 mod test {
 
@@ -95,8 +102,10 @@ mod test {
     fn expected_size() {
         let mut bit_vector: Vec<u8> = vec![0; 63];
 
-        // Since the first byte specifies the compression algorithm, an error is expected.
+        // Expect for an error because of the different uncompressed size.
         assert!(merkle_root_from_compressed_bytes(&bit_vector, bit_vector.len()).is_err());
+        // No errors expected if the uncompressed size is fine.
+        assert!(merkle_root_from_compressed_bytes(&bit_vector, bit_vector.len() - 1).is_ok());
 
         bit_vector.clear();
         bit_vector.push(0);
@@ -107,6 +116,21 @@ mod test {
         
         assert!(merkle_root_from_compressed_bytes(&bit_vector, bit_vector.len() - 1).is_ok());
 
+    }
+
+    #[test]
+    fn without_size_checks() {
+        let mut bit_vector: Vec<u8> = vec![0; 63];
+        assert!(merkle_root_from_compressed_bytes_without_checks(&bit_vector).is_ok());
+
+        bit_vector.clear();
+        bit_vector.push(0);
+
+        for i in 0..63 {
+            bit_vector.push(i);
+        }
+
+        assert!(merkle_root_from_compressed_bytes_without_checks(&bit_vector).is_ok());
     }
 
     #[test]

--- a/cctp_primitives/src/proving_system/init.rs
+++ b/cctp_primitives/src/proving_system/init.rs
@@ -12,8 +12,6 @@ use lazy_static::lazy_static;
 use std::sync::{
     RwLock, RwLockReadGuard
 };
-use std::fs::File;
-use std::path::Path;
 
 // We need a mutable static variable to store the committer key.
 // To avoid the usage of unsafe code blocks (required when mutating a static variable)
@@ -29,16 +27,14 @@ lazy_static! {
     pub static ref G2_COMMITTER_KEY: RwLock<Option<CommitterKeyG2>> = RwLock::new(None);
 }
 
-/// Load G1CommitterKey of degree `supported_degree` from `file_path` if it exists, otherwise create it,
-/// load it, and save it into a new file at `file_path`. The parameter `max_degree` is required
-/// in order to derive a unique hash for the key itself.
+/// Generate G1CommitterKey and store it in memory.
+/// The parameter `max_degree` is required in order to derive a unique hash for the key itself.
 pub fn load_g1_committer_key(
     max_degree: usize,
     supported_degree: usize,
-    file_path: &Path
 ) -> Result<(), SerializationError>
 {
-    match load_generators::<G1>(max_degree, supported_degree, file_path) {
+    match load_generators::<G1>(max_degree, supported_degree) {
         // Generation/Loading successfull, assign the key to the lazy_static
         Ok(loaded_key) => {
             G1_COMMITTER_KEY.write().as_mut().unwrap().replace(loaded_key);
@@ -49,16 +45,14 @@ pub fn load_g1_committer_key(
     }
 }
 
-/// Load G2CommitterKey of degree `supported_degree` from `file_path` if it exists, otherwise create it,
-/// load it, and save it into a new file at `file_path`. The parameter `max_degree` is required
-/// in order to derive a unique hash for the key itself.
+/// Generate G2CommitterKey and store it in memory.
+/// The parameter `max_degree` is required in order to derive a unique hash for the key itself.
 pub fn load_g2_committer_key(
     max_degree: usize,
     supported_degree: usize,
-    file_path: &Path
 ) -> Result<(), SerializationError>
 {
-    match load_generators::<G2>(max_degree, supported_degree, file_path) {
+    match load_generators::<G2>(max_degree, supported_degree) {
         // Generation/Loading successful, assign the key to the lazy_static
         Ok(loaded_key) => {
             G2_COMMITTER_KEY.write().as_mut().unwrap().replace(loaded_key);
@@ -96,32 +90,15 @@ pub fn get_g2_committer_key<'a>() -> Result<RwLockReadGuard<'a, Option<Committer
 fn load_generators<G: AffineCurve>(
     max_degree: usize,
     supported_degree: usize,
-    file_path: &Path
 ) -> Result<CommitterKey<G>, SerializationError>
 {
-    let mut pk: CommitterKey<G>;
-
-    if file_path.exists() {
-        // Try to read the CommitterKey from file
-        let fs = File::open(file_path).map_err(|e| SerializationError::IoError(e))?;
-        pk = CanonicalDeserialize::deserialize(fs)?;
-        if pk.max_degree == max_degree {
-            return Ok(pk)
-        }
-    }
-
-    // File doesn't exist or the pk is smaller than the requested max_degree:
-    // generate the committer key and save it to file
     let pp = InnerProductArgPC::<G, Digest>::setup(max_degree)
         .map_err(|_| SerializationError::InvalidData)?;
     let (ck, _) = InnerProductArgPC::<G, Digest>::trim(&pp, supported_degree)
         .map_err(|_| SerializationError::InvalidData)?;
-    pk = ck;
-    let fs = File::create(file_path).map_err(|e| SerializationError::IoError(e))?;
-    CanonicalSerialize::serialize(&pk, fs)?;
 
     // Return the read/generated committer key
-    Ok(pk)
+    Ok(ck)
 }
 
 #[cfg(test)]
@@ -130,8 +107,6 @@ mod test {
 
     use poly_commit::ipa_pc::InnerProductArgPC;
     use poly_commit::PolynomialCommitment;
-
-    use std::fs::{File, remove_file};
     use serial_test::serial;
 
     #[test]
@@ -139,16 +114,11 @@ mod test {
     fn check_load_g1_committer_key() {
         let max_degree = 1 << 10;
         let supported_degree = 1 << 9;
-        let mut file_path = std::env::temp_dir();
-        file_path.push("sample_ck_g1");
 
         let pp = InnerProductArgPC::<G1, Digest>::setup(max_degree).unwrap();
         let (pk, _) = InnerProductArgPC::<G1, Digest>::trim(&pp, supported_degree).unwrap();
 
-        let fs = File::create(&file_path).unwrap();
-        CanonicalSerialize::serialize(&pk, fs).unwrap();
-
-        load_g1_committer_key(max_degree, supported_degree, &file_path).unwrap();
+        load_g1_committer_key(max_degree, supported_degree).unwrap();
 
         let ck = get_g1_committer_key().unwrap();
 
@@ -162,8 +132,6 @@ mod test {
         assert_eq!(pk.max_degree, ck.max_degree);
         assert_eq!(pk.hash, ck.hash);
         assert_eq!(pp.hash, ck.hash);
-
-        remove_file(&file_path).unwrap();
     }
 
     #[test]
@@ -171,16 +139,11 @@ mod test {
     fn check_load_g2_committer_key() {
         let max_degree = 1 << 10;
         let supported_degree = 1 << 9;
-        let mut file_path = std::env::temp_dir();
-        file_path.push("sample_ck_g2");
 
         let pp = InnerProductArgPC::<G2, Digest>::setup(max_degree).unwrap();
         let (pk, _) = InnerProductArgPC::<G2, Digest>::trim(&pp, supported_degree).unwrap();
 
-        let fs = File::create(&file_path).unwrap();
-        CanonicalSerialize::serialize(&pk, fs).unwrap();
-
-        load_g2_committer_key(max_degree, supported_degree, &file_path).unwrap();
+        load_g2_committer_key(max_degree, supported_degree).unwrap();
 
         let ck = get_g2_committer_key().unwrap();
 
@@ -194,7 +157,5 @@ mod test {
         assert_eq!(pk.max_degree, ck.max_degree);
         assert_eq!(pk.hash, ck.hash);
         assert_eq!(pp.hash, ck.hash);
-
-        remove_file(&file_path).unwrap();
     }
 }

--- a/cctp_primitives/src/proving_system/mod.rs
+++ b/cctp_primitives/src/proving_system/mod.rs
@@ -9,7 +9,6 @@ use crate::{
         error::ProvingSystemError
     }
 };
-use std::path::Path;
 
 pub mod init;
 pub mod verifier;
@@ -226,18 +225,16 @@ pub fn init_dlog_keys(
     proving_system: ProvingSystem,
     max_segment_size: usize,
     supported_segment_size: usize,
-    ck_g1_path: &Path,
-    ck_g2_path: &Path,
 ) -> Result<(), Error> {
 
     if matches!(proving_system, ProvingSystem::Undefined) {
         return Err(ProvingSystemError::UndefinedProvingSystem)?
     }
 
-    load_g1_committer_key(max_segment_size - 1, supported_segment_size - 1, ck_g1_path)?;
+    load_g1_committer_key(max_segment_size - 1, supported_segment_size - 1)?;
 
     if matches!(proving_system, ProvingSystem::Darlin) {
-        load_g2_committer_key(max_segment_size - 1, supported_segment_size - 1, ck_g2_path)?
+        load_g2_committer_key(max_segment_size - 1, supported_segment_size - 1)?
     }
 
     Ok(())

--- a/cctp_primitives/src/proving_system/verifier/batch_verifier.rs
+++ b/cctp_primitives/src/proving_system/verifier/batch_verifier.rs
@@ -170,9 +170,6 @@ mod test {
     };
     use poly_commit::ipa_pc::UniversalParams;
     use rand::{thread_rng, Rng};
-    use std::{
-        path::PathBuf, convert::TryInto,
-    };
     use serial_test::serial;
 
     // ***********************Tests with real test circuit*************************
@@ -193,19 +190,14 @@ mod test {
         UniversalParams<G2>,
         usize,
         usize,
-        PathBuf,
-        PathBuf,
     ) {
 
         let max_pow = 7usize;
         let segment_size = 1 << max_pow;
 
         // Init committer keys
-        let mut g1_ck_path = std::env::temp_dir();
-        g1_ck_path.push("ck_g1");
-
         let committer_key_g1 = {
-            load_g1_committer_key(segment_size - 1, segment_size - 1, &g1_ck_path).unwrap();
+            load_g1_committer_key(segment_size - 1, segment_size - 1).unwrap();
             get_g1_committer_key().unwrap()
         }.as_ref().unwrap().clone();
 
@@ -216,11 +208,8 @@ mod test {
             s: committer_key_g1.s.clone(),
         };
 
-        let mut g2_ck_path = std::env::temp_dir();
-        g2_ck_path.push("ck_g2");
-
         let committer_key_g2 = {
-            load_g2_committer_key(segment_size - 1, segment_size - 1,  &g2_ck_path).unwrap();
+            load_g2_committer_key(segment_size - 1, segment_size - 1).unwrap();
             get_g2_committer_key().unwrap()
         }.as_ref().unwrap().clone();
 
@@ -231,7 +220,7 @@ mod test {
             s: committer_key_g2.s.clone(),
         };
 
-        (params_g1, params_g2, max_pow, segment_size, g1_ck_path, g2_ck_path)
+        (params_g1, params_g2, max_pow, segment_size)
     }
 
     #[test]
@@ -245,8 +234,6 @@ mod test {
             params_g2,
             max_pow,
             segment_size,
-            g1_ck_path,
-            g2_ck_path
         ) = get_params();
         let num_constraints = segment_size;
 
@@ -308,10 +295,6 @@ mod test {
             let res = verify_zendoo_proof(wrong_usr_ins, &proof, &vk, Some(generation_rng));
             assert!(res.is_err() || !res.unwrap());
         }
-
-        // Cleanup
-        let _ = std::fs::remove_file(&g1_ck_path);
-        let _ = std::fs::remove_file(&g2_ck_path);
     }
 
     #[test]
@@ -327,8 +310,6 @@ mod test {
             params_g2,
             max_pow,
             segment_size,
-            g1_ck_path,
-            g2_ck_path
         ) = get_params();
         let num_constraints = segment_size;
 
@@ -420,10 +401,6 @@ mod test {
             },
             _ => panic!(),
         }
-
-        // Cleanup
-        let _ = std::fs::remove_file(&g1_ck_path);
-        let _ = std::fs::remove_file(&g2_ck_path);
     }
 
     // ************Tests with mocks for certificate and csw proofs batch verifier***************
@@ -519,6 +496,8 @@ mod test {
     #[serial]
     #[test]
     fn dummy_batch_verifier_test() {
+        use std::convert::TryInto;
+
         let num_proofs = 100;
         let generation_rng = &mut thread_rng();
         let mut batch_verifier = TestZendooBatchVerifier::create();
@@ -527,8 +506,6 @@ mod test {
             params_g2,
             _,
             segment_size,
-            g1_ck_path,
-            g2_ck_path
         ) = get_params();
         let num_constraints = segment_size;
 
@@ -644,9 +621,5 @@ mod test {
             },
             _ => panic!(),
         }
-
-        // Cleanup
-        let _ = std::fs::remove_file(&g1_ck_path);
-        let _ = std::fs::remove_file(&g2_ck_path);
     }
 }


### PR DESCRIPTION
- Don't save the DLOG Keys to file anymore but re-generate them each time the load_g{1,2}_committer_key is called. The reason for this is that a (compressed, checked) and (uncompressed, checked) serialization is a lot slower than re-generating the key; even if a (uncompressed, unchecked) deserialization is much faster, it's unsafe: we need to compute, save and check the hash of the key to be sure that nothing happened. Given that the DLOG key generation time is not an issue and that, in real practice, we need to re-generate the key seldom, we decided to avoid this additional complexity and re-generate the keys each time, simplifying the logic and the interfaces;
- ...