### PR TITLE
Added "static" feature to the Bzip2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,8 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "algebra"
-version = "0.3.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra-derive",
  "byteorder",
@@ -26,7 +26,7 @@ dependencies = [
 [[package]]
 name = "algebra-derive"
 version = "0.2.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -41,8 +41,8 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bench-utils"
-version = "0.3.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 
 [[package]]
 name = "bit-vec"
@@ -231,7 +231,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "field-assembly"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "mince",
 ]
@@ -315,8 +315,8 @@ dependencies = [
 
 [[package]]
 name = "marlin"
-version = "0.2.1"
-source = "git+https://github.com/HorizenLabs/marlin?branch=dev#57e3c2d10ecd9df314c84e53a012929dc5172a6f"
+version = "0.2.2"
+source = "git+https://github.com/HorizenLabs/marlin?branch=dev#1aca34c169da3162e1ba6dd591283ff721d11b5e"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -343,7 +343,7 @@ dependencies = [
 [[package]]
 name = "mince"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "quote",
  "syn",
@@ -447,8 +447,8 @@ checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "poly-commit"
-version = "0.2.0"
-source = "git+https://github.com/HorizenLabs/poly-commit?branch=dev#c99a265d74869ac747fa82df4215b7ad30a94d38"
+version = "0.2.2"
+source = "git+https://github.com/HorizenLabs/poly-commit?branch=dev#d3e3ac5143a441e2876536382ee1e8f15884bfbe"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -468,8 +468,8 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitives"
-version = "0.3.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -491,8 +491,8 @@ dependencies = [
 
 [[package]]
 name = "proof-systems"
-version = "0.3.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -520,8 +520,8 @@ dependencies = [
 
 [[package]]
 name = "r1cs-core"
-version = "0.3.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
  "radix_trie",
@@ -531,8 +531,8 @@ dependencies = [
 
 [[package]]
 name = "r1cs-std"
-version = "0.3.1"
-source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#96e2065c5cf5b711dd302860af7bd8a13be740bd"
+version = "0.4.0"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#c0f35a95673cea39d07380c6b7180c154e3e7228"
 dependencies = [
  "algebra",
  "derivative",

--- a/cctp_primitives/Cargo.toml
+++ b/cctp_primitives/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "=1.4.0"
 blake2 = { version = "=0.8.1", default-features = false }
 sha1 = "=0.6.0"
 bit-vec = "=0.6.3"
-bzip2 = "=0.4.3"
+bzip2 = { version = "=0.4.3", features = ["static"] }
 flate2 = "=1.0.21"
 
 [dev-dependencies]


### PR DESCRIPTION
It was required to export all the Bzip2 symbols so that Zend could correctly include the CCTP Lib (through the MC Crypto Lib) without separately linking Bzip2.