### PR TITLE
Exposed the "supported degree" parameter in verification functions

### DIFF
--- a/cctp_primitives/src/proving_system/verifier/batch_verifier.rs
+++ b/cctp_primitives/src/proving_system/verifier/batch_verifier.rs
@@ -92,17 +92,32 @@ impl ZendooBatchVerifier {
         Ok(result)
     }
 
-    /// Verify only the proofs whose id is contained in `ids`.
-    /// If the verification procedure fails, it may be possible to get the id of
-    /// the proof that has caused the failure.
     pub fn batch_verify_subset<R: RngCore>(
         &self,
         ids: Vec<u32>,
         rng: &mut R,
     ) -> Result<bool, ProvingSystemError> {
+        self.batch_verify_subset_with_segment_size(ids, rng, None)
+    }
+
+    /// Verify only the proofs whose id is contained in `ids`.
+    /// If the verification procedure fails, it may be possible to get the id of
+    /// the proof that has caused the failure.
+    pub fn batch_verify_subset_with_segment_size<R: RngCore>(
+        &self,
+        ids: Vec<u32>,
+        rng: &mut R,
+        segment_size: Option<usize>
+    ) -> Result<bool, ProvingSystemError> {
         // Retrieve committer keys
-        let g1_ck = get_g1_committer_key(None)?;
-        let g2_ck = get_g2_committer_key(None)?;
+        let supported_degree: Option<usize> = {
+            match segment_size {
+                Some(seg_size) => Some(seg_size - 1),
+                None => None,
+            }
+        };
+        let g1_ck = get_g1_committer_key(supported_degree)?;
+        let g2_ck = get_g2_committer_key(supported_degree)?;
 
         if ids.is_empty() {
             Err(ProvingSystemError::NoProofsToVerify)

--- a/cctp_primitives/src/proving_system/verifier/batch_verifier.rs
+++ b/cctp_primitives/src/proving_system/verifier/batch_verifier.rs
@@ -281,7 +281,7 @@ mod test {
             test_canonical_serialize_deserialize(true, &vk);
 
             // Verification success
-            assert!(verify_zendoo_proof(usr_ins, &proof, &vk, Some(generation_rng)).unwrap());
+            assert!(verify_zendoo_proof(usr_ins, &proof, &vk, Some(iteration_segment_size), Some(generation_rng)).unwrap());
 
             // Verification failure
             let wrong_usr_ins = TestCircuitInputs {
@@ -289,7 +289,7 @@ mod test {
                 d: generation_rng.gen(),
             };
 
-            let res = verify_zendoo_proof(wrong_usr_ins, &proof, &vk, Some(generation_rng));
+            let res = verify_zendoo_proof(wrong_usr_ins, &proof, &vk, Some(iteration_segment_size), Some(generation_rng));
             assert!(res.is_err() || !res.unwrap());
         }
     }

--- a/cctp_primitives/src/proving_system/verifier/mod.rs
+++ b/cctp_primitives/src/proving_system/verifier/mod.rs
@@ -21,6 +21,7 @@ pub fn verify_zendoo_proof<I: UserInputs, R: RngCore>(
     inputs: I,
     proof: &ZendooProof,
     vk: &ZendooVerifierKey,
+    segment_size: Option<usize>,
     rng: Option<&mut R>,
 ) -> Result<bool, ProvingSystemError> {
     let usr_ins = inputs.get_circuit_inputs()?;
@@ -29,7 +30,12 @@ pub fn verify_zendoo_proof<I: UserInputs, R: RngCore>(
         return Err(ProvingSystemError::ProvingSystemMismatch);
     }
 
-    let ck_g1 = get_g1_committer_key(None)?;
+    let supported_degree: Option<usize> = match segment_size {
+        Some(s) => Some(s - 1),
+        None => None,
+    };
+
+    let ck_g1 = get_g1_committer_key(supported_degree)?;
 
     // Verify proof (selecting the proper proving system)
     let res = match (proof, vk) {


### PR DESCRIPTION
This is useful to test (e.g. in MC Crypto Lib) that a proof generated with a segment size cannot be verified with a different value.