### PR TITLE
Undo update to tagged dependencies for ginger-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 [[package]]
 name = "algebra"
 version = "0.4.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "algebra-derive",
  "byteorder",
@@ -26,7 +26,7 @@ dependencies = [
 [[package]]
 name = "algebra-derive"
 version = "0.2.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -42,7 +42,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "bench-utils"
 version = "0.4.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 
 [[package]]
 name = "bit-vec"
@@ -231,7 +231,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "field-assembly"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "mince",
 ]
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "marlin"
 version = "0.2.2"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -344,7 +344,7 @@ dependencies = [
 [[package]]
 name = "mince"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "quote",
  "syn",
@@ -449,7 +449,7 @@ checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 [[package]]
 name = "poly-commit"
 version = "0.2.2"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -471,7 +471,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 [[package]]
 name = "primitives"
 version = "0.4.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "proof-systems"
 version = "0.4.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "algebra",
  "bench-utils",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "r1cs-core"
 version = "0.4.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "algebra",
  "radix_trie",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "r1cs-std"
 version = "0.4.0"
-source = "git+https://github.com/HorizenOfficial/ginger-lib.git?tag=0.5.0-alpha1#71ad1577f182bc597c94e5ba27712f62e14735b4"
+source = "git+https://github.com/HorizenOfficial/ginger-lib?branch=development#25384653cc9818bbecea1108ef31e5f3930758cf"
 dependencies = [
  "algebra",
  "derivative",

--- a/cctp_primitives/Cargo.toml
+++ b/cctp_primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cctp_primitives"
-version = "0.2.0-alpha2"
+version = "0.1.2"
 authors = [
     "Alberto Benegiamo",
     "Daniele Di Benedetto <daniele@horizenlabs.io>",
@@ -16,12 +16,12 @@ authors = [
 edition = "2018"
 
 [dependencies]
-algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", tag = "0.5.0-alpha1", features = ["parallel", "tweedle", "derive"] }
-primitives = { git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.5.0-alpha1", features = ["merkle_tree", "tweedle"]}
-proof-systems = { git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.5.0-alpha1", features = ["darlin"]}
+algebra = { git = "https://github.com/HorizenOfficial/ginger-lib", branch = "development", features = ["parallel", "tweedle", "derive"] }
+primitives = { git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development", features = ["merkle_tree", "tweedle"]}
+proof-systems = { git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development", features = ["darlin"]}
 
-marlin = { git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.5.0-alpha1" }
-poly-commit = { git = "https://github.com/HorizenOfficial/ginger-lib.git", tag = "0.5.0-alpha1" }
+marlin = { git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development" }
+poly-commit = { git = "https://github.com/HorizenOfficial/ginger-lib.git", branch = "development" }
 
 rand = { version = "=0.8.4" }
 byteorder = "=1.4.3"


### PR DESCRIPTION
Temporarily restore dependencies to ginger-lib crates to development branch rather than to the new `0.5.0-alpha1` tag, as this contains still unreviewed fixes.